### PR TITLE
add codecov

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,3 +46,5 @@ jobs:
     - name: Test using make test
       run: |
         make test
+        coverage report -m
+        codecov --token=${{secrets.CODECOV_TOKEN}}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-django
 django
 django-crispy-forms
+codecov


### PR DESCRIPTION
@carltongibson @bryan-brancotte  I've added codecov to the GH actions CI. 

Questions:

1. Is this something we want, and is codecov the right option? 
2. Need to add a secret key (with `CODECOV_TOKEN` as the name) to the repo for the upload to work. Carlton, assume would be one for you? 

p.s. not quite sure why it takes a while to complete once all the tests have passed. 