### PR TITLE
explicitly list package data

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,3 @@
-black
+black~=22.6.0
 isort
 flake8

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,8 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
+        "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
     ],
     package_data={
         "crispy_forms_bootstrap2": [

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,12 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
     ],
+    package_data={
+        'crispy_forms_bootstrap2': [
+            'templates/bootstrap/*',
+            'templates/bootstrap/layout/*',
+        ],
+    },
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,9 @@ setup(
         "Framework :: Django :: 4.1",
     ],
     package_data={
-        'crispy_forms_bootstrap2': [
-            'templates/bootstrap/*',
-            'templates/bootstrap/layout/*',
+        "crispy_forms_bootstrap2": [
+            "templates/bootstrap/*",
+            "templates/bootstrap/layout/*",
         ],
     },
     include_package_data=True,

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,9 @@ max_line_length=118
 
 [tox]
 envlist =
-    {py37,py38,py39,py310}-django{32}-crispy{-latest},
-    {py38,py39,py310}-django{40,41,-latest}-crispy{-latest},
+    {py37,py38,py39,py310}-django{32}-crispy{2.0},
+    {py38,py39,py310}-django{40,41,42,-latest}-crispy{2.0},
+    {py310}-django{42,50,-latest}-crispy{-latest},
     lint
 
 [testenv]
@@ -12,6 +13,8 @@ deps =
     django32: django>=3.2,<3.3
     django40: django>=4.0a,<4.1
     django41: django>=4.1a,<4.2
+    django42: django>=4.2a,<5.0
+    django50: django>=5.0a,<5.0
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
     -rrequirements/testing.txt
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     django40: django>=4.0a,<4.1
     django41: django>=4.1a,<4.2
     django42: django>=4.2a,<5.0
-    django50: django>=5.0a,<5.0
+    django50: django>=5.0,<5.1
     crispy-latest: https://github.com/django-crispy-forms/django-crispy-forms/archive/main.tar.gz
     -rrequirements/testing.txt
 commands = python -W error::DeprecationWarning -W error::PendingDeprecationWarning -m pytest {posargs}


### PR DESCRIPTION
when ran locally with setuptools 69.0.3 html file are now included (not working with 48.0.0)